### PR TITLE
Add postcode field to cluster_info.yaml

### DIFF
--- a/data/cluster_info.yaml
+++ b/data/cluster_info.yaml
@@ -22,6 +22,7 @@ partitions: # a list of the different partitions on the cluster
   # You can keep adding partitions to this
 PUE: <1.67> # [number > 1] Power Usage Effectiveness of the facility
 CI: <467> # [number] average carbon intensity of the geographic location, in gCO2e/kWh
+postcode: <Postcode> # [str] Postcode of the facility
 energy_cost:
   cost: <0.34> # [number] in currency/kWh
   currency: "<£>" # [str]


### PR DESCRIPTION
Adding the '`postcode`' field in `cluster_info.yaml` file to allow users to utilize the CarbonIntensity API that is integrated with [GA core](https://github.com/Cambridge-Sustainable-Computing-Lab/Green-Algorithms-core) for UK based clusters.